### PR TITLE
Fixed fatal error when running import with wpml-all-import on CLI.

### DIFF
--- a/patches/wpml-all-import.0001.fix.fatal-error-cli.patch
+++ b/patches/wpml-all-import.0001.fix.fatal-error-cli.patch
@@ -1,7 +1,7 @@
 From cca7df80a08042cd23d56de1f5f8139f24b39b7b Mon Sep 17 00:00:00 2001
 From: Fabian Marz <fabian@netzstrategen.com>
 Date: Thu, 24 Feb 2022 16:14:08 +0100
-Subject: [PATCH] Fixed plugin wpml-all-import throws error when used via CLI.
+Subject: [PATCH] Fixed fatal error when running import with wpml-all-import on CLI.
 
 Upstream: https://wpml.org/forums/topic/fatal-error-when-running-an-import-using-wp-cli/#post-7636799
 ---

--- a/patches/wpml-all-import.0001.fix.wpml-all-import-cli.patch
+++ b/patches/wpml-all-import.0001.fix.wpml-all-import-cli.patch
@@ -3,6 +3,7 @@ From: Fabian Marz <fabian@netzstrategen.com>
 Date: Thu, 24 Feb 2022 16:14:08 +0100
 Subject: [PATCH] Fixed plugin wpml-all-import throws error when used via CLI.
 
+Upstream: https://wpml.org/forums/topic/fatal-error-when-running-an-import-using-wp-cli/#post-7636799
 ---
  wpml-all-import.php | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/patches/wpml-all-import.0001.fix.wpml-all-import-cli.patch
+++ b/patches/wpml-all-import.0001.fix.wpml-all-import-cli.patch
@@ -1,0 +1,28 @@
+From cca7df80a08042cd23d56de1f5f8139f24b39b7b Mon Sep 17 00:00:00 2001
+From: Fabian Marz <fabian@netzstrategen.com>
+Date: Thu, 24 Feb 2022 16:14:08 +0100
+Subject: [PATCH] Fixed plugin wpml-all-import throws error when used via CLI.
+
+---
+ wpml-all-import.php | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wpml-all-import.php b/wpml-all-import.php
+index 97fe2a51..4aabef60 100644
+--- a/wpml-all-import.php
++++ b/wpml-all-import.php
+@@ -9,9 +9,9 @@
+ 	Author URI: http://www.onthegosystems.com/
+ */
+ 
+-require_once "includes/rapid-addon.php";
++require_once  __DIR__ . "/includes/rapid-addon.php";
+ 
+-require_once "vendor/autoload.php";
++require_once  __DIR__ . "/vendor/autoload.php";
+ 
+ if ( ! class_exists('WPAI_WPML') )
+ {
+-- 
+2.28.0
+


### PR DESCRIPTION
Solution copied from https://wpml.org/forums/topic/fatal-error-when-running-an-import-using-wp-cli/#post-7636799. This issue still exists in v2.3.0 of the plugin.