### PR TITLE
Fixed export patches command plugin name.

### DIFF
--- a/src/ExportPatchesCommand.php
+++ b/src/ExportPatchesCommand.php
@@ -33,7 +33,7 @@ class ExportPatchesCommand extends \WP_CLI_Command {
     foreach (glob(dirname(__DIR__) . "/patches/*.patch") as $patch) {
       $patch_parts = explode('.', basename($patch));
       $plugin = reset($patch_parts);
-      $plugin_name = (array) array_filter($dependencies, fn($dependency) => strpos($dependency, $plugin) !== FALSE);
+      $plugin_name = (array) array_filter($dependencies, fn($dependency) => end(explode('/', $dependency)) === $plugin);
       $plugin_name = reset($plugin_name);
       if (!$plugin_name) {
         continue;


### PR DESCRIPTION
If we have a 2 dependencies that are called woocommerce-XXXX  and a plugin name that is woocommerce strpos will give positive that filter should check instead if `$dependency` and `$plugin` are the same, and not if is a substring.