### PR TITLE
Fixed package namespace missing in exported composer patches.

### DIFF
--- a/src/ExportPatchesCommand.php
+++ b/src/ExportPatchesCommand.php
@@ -26,11 +26,15 @@ class ExportPatchesCommand extends \WP_CLI_Command {
     if (!$composer_json) {
       return;
     }
-    $dependencies = array_map(
-      fn($dependency) => basename($dependency),
-      array_keys($composer_json['require'])
-    );
-    $dependencies = array_combine($dependencies, $dependencies);
+
+    $dependencies = [];
+    foreach(array_keys($composer_json['require']) as $dependecy) {
+      $dependencies = $dependencies + [basename($dependecy) => $dependecy];
+    }
+
+    if (!$dependencies) {
+      \WP_CLI::error('No dependencies found in composer.json.');
+    }
 
     $patches = [];
     foreach (glob(dirname(__DIR__) . "/patches/*.patch") as $patch) {
@@ -40,7 +44,7 @@ class ExportPatchesCommand extends \WP_CLI_Command {
       if (!isset($dependencies[$plugin_name])) {
         continue;
       }
-      $patches[$plugin_name][$keywords] = './.wp-cli/packages/shared-patches/patches/' . basename($patch);
+      $patches[$dependencies[$plugin_name]][$keywords] = './.wp-cli/packages/shared-patches/patches/' . basename($patch);
     }
     // Map all references to 'patches.json', and then reference this as
     // `patches-file` in the root composer.json.

--- a/src/ExportPatchesCommand.php
+++ b/src/ExportPatchesCommand.php
@@ -28,8 +28,8 @@ class ExportPatchesCommand extends \WP_CLI_Command {
     }
 
     $dependencies = [];
-    foreach (array_keys($composer_json['require']) as $dependecy) {
-      $dependencies[basename($dependecy)] = $dependecy;
+    foreach (array_keys($composer_json['require']) as $dependency) {
+      $dependencies[basename($dependency)] = $dependency;
     }
 
     if (!$dependencies) {

--- a/src/ExportPatchesCommand.php
+++ b/src/ExportPatchesCommand.php
@@ -28,8 +28,8 @@ class ExportPatchesCommand extends \WP_CLI_Command {
     }
 
     $dependencies = [];
-    foreach(array_keys($composer_json['require']) as $dependecy) {
-      $dependencies = $dependencies + [basename($dependecy) => $dependecy];
+    foreach (array_keys($composer_json['require']) as $dependecy) {
+      $dependencies[basename($dependecy)] = $dependecy;
     }
 
     if (!$dependencies) {


### PR DESCRIPTION
## Description
The `wp patch export`  command is exporting the patches without the package prefix/namespace 
and hence `composer patch `command cannot apply the patch because it cannot find it
E.g. 

```
"woocommerce": {
            "php-notice-paypal-invalid-api-keys": ".\/.wp-cli\/packages\/shared-patches\/patches\/woocommerce.0001.fix.php-notice-paypal-invalid-api-keys.patch",
            "array_slice-arg-type": ".\/.wp-cli\/packages\/shared-patches\/patches\/woocommerce.0002.fix.array_slice-arg-type.patch"
        }
```
Instead of 

```
"wpackagist-plugin\/woocommerce": {
            "php-notice-paypal-invalid-api-keys": ".\/.wp-cli\/packages\/shared-patches\/patches\/woocommerce.0001.fix.php-notice-paypal-invalid-api-keys.patch",
            "array_slice-arg-type": ".\/.wp-cli\/packages\/shared-patches\/patches\/woocommerce.0002.fix.array_slice-arg-type.patch"
        }
```
