### PR TITLE
Fixed woochimp null variable php notice.

### DIFF
--- a/patches/woochimp.0002.fix.php-notice-woochimp-checkout-empty-groups.patch
+++ b/patches/woochimp.0002.fix.php-notice-woochimp-checkout-empty-groups.patch
@@ -16,7 +16,7 @@ index 0fe680b..85e25e6 100644
          if ($already_subscribed === false || ($already_subscribed && ($this->opt['woochimp_hide_checkbox'] == '2' || ($this->opt['woochimp_hide_checkbox'] == '3' && !empty($groups['data']) && !empty($groups['html']))))) {
              echo $checkbox_block;
 -            echo $groups['html'];
-+            if (!empty($groups['html'])) {
++            if (!empty($groups) && !empty($groups['html'])) {
 +                echo $groups['html'];
 +            }
          }


### PR DESCRIPTION
[Fix PHP notice: page /kasse: warning notice from WooChimp](https://app.asana.com/0/1202867909936929/1203865089583539)