### PR TITLE
Fixed sitepress-multilingual-cms patches not applying after plugin update.

### DIFF
--- a/patches/sitepress-multilingual-cms.0001.fix.fatal-error-translation-management.patch
+++ b/patches/sitepress-multilingual-cms.0001.fix.fatal-error-translation-management.patch
@@ -1,31 +1,32 @@
-From e42cb5156c9aba97518dca8abb9d1c33ee17ab2e Mon Sep 17 00:00:00 2001
-From: Daniel Kudwien <daniel@netzstrategen.com>
-Date: Tue, 23 Aug 2022 14:28:38 +0200
+From 413a0d8b1e402e73ec65e278da802a2e5950ed83 Mon Sep 17 00:00:00 2001
+From: adabaca <ada@olivestudio.ro>
+Date: Thu, 27 Apr 2023 10:06:02 +0300
 Subject: [PATCH] Fixed fatal error on admin-ajax.php when editing pages due to
- WPML loading Translation Management despite being disabled.
+ WPML loading Translation Management despite being disabled, after update.
 
 ---
- inc/functions-load.php | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ classes/ATE/API/class-wpml-tm-ate-authentication.php | 2 +-
+ inc/functions-load.php                               | 4 +++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
-diff --git a/wp-content/plugins/sitepress-multilingual-cms/classes/ATE/API/class-wpml-tm-ate-authentication.php b/wp-content/plugins/sitepress-multilingual-cms/classes/ATE/API/class-wpml-tm-ate-authentication.php
-index 28e0adaaa..d1550b3ab 100644
+diff --git a/classes/ATE/API/class-wpml-tm-ate-authentication.php b/classes/ATE/API/class-wpml-tm-ate-authentication.php
+index 81e740b22..d542fd57f 100644
 --- a/classes/ATE/API/class-wpml-tm-ate-authentication.php
 +++ b/classes/ATE/API/class-wpml-tm-ate-authentication.php
 @@ -106,7 +106,7 @@ class WPML_TM_ATE_Authentication {
-                }
+ 		}
  
-                $query['wpml_core_version'] = ICL_SITEPRESS_VERSION;
--               $query['wpml_tm_version']   = WPML_TM_VERSION;
-+               $query['wpml_tm_version']   = defined('WPML_TM_VERSION') ? WPML_TM_VERSION : '0.0';
-                $query['shared_key']        = $this->get_shared();
-                $query['token']             = uuid_v5( wp_generate_uuid4(), $url );
-                $query['website_uuid']      = $this->get_site_id();
+ 		$query['wpml_core_version'] = ICL_SITEPRESS_VERSION;
+-		$query['wpml_tm_version']   = WPML_TM_VERSION;
++		$query['wpml_tm_version']   = defined('WPML_TM_VERSION') ? WPML_TM_VERSION : '0.0';
+ 		$query['shared_key']        = $this->get_shared();
+ 		$query['token']             = uuid_v5( wp_generate_uuid4(), $url );
+ 		$query['website_uuid']      = $this->get_site_id();
 diff --git a/inc/functions-load.php b/inc/functions-load.php
-index 7851afe60..dd9b51967 100644
+index e71324361..98faa84ec 100644
 --- a/inc/functions-load.php
 +++ b/inc/functions-load.php
-@@ -433,4 +433,6 @@ if ( is_admin() ) {
+@@ -434,4 +434,6 @@ if ( is_admin() ) {
  
  
  // TM
@@ -34,5 +35,5 @@ index 7851afe60..dd9b51967 100644
 +	require_once 'functions-load-tm.php';
 +}
 -- 
-2.25.1
+2.34.1
 

--- a/patches/sitepress-multilingual-cms.0002.fix.term-id-not-matching-term-taxonomy-id.patch
+++ b/patches/sitepress-multilingual-cms.0002.fix.term-id-not-matching-term-taxonomy-id.patch
@@ -1,56 +1,34 @@
-From 278ec4f6d56586f60772f336d049b527feeddfd1 Mon Sep 17 00:00:00 2001
-From: Marc del Amo <marc.delamo@gmail.com>
-Date: Tue, 18 Apr 2023 19:04:27 +0200
-Subject: [PATCH] Fixed WPML term IDs not equal to term taxonomy IDs.
+From 04df782684cfbe2e7e47d07bcc5c1a6eb4a51bbf Mon Sep 17 00:00:00 2001
+From: adabaca <ada@olivestudio.ro>
+Date: Thu, 27 Apr 2023 10:28:39 +0300
+Subject: [PATCH] Fixed WPML term IDs not equal to term taxonomy IDs, after
+ update.
 
 ---
- .../wpml-term-translation.class.php           | 29 ++++++++++---------
- 1 file changed, 15 insertions(+), 14 deletions(-)
+ .../wpml-term-translation.class.php                    | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/inc/taxonomy-term-translation/wpml-term-translation.class.php b/inc/taxonomy-term-translation/wpml-term-translation.class.php
-index 78b6179af..c2301fd85 100644
+index e7806b726..6aa518366 100644
 --- a/inc/taxonomy-term-translation/wpml-term-translation.class.php
 +++ b/inc/taxonomy-term-translation/wpml-term-translation.class.php
-@@ -118,24 +118,25 @@ class WPML_Term_Translation extends WPML_Element_Translation {
- 	private function maybe_warm_term_id_cache() {
+@@ -131,11 +131,11 @@ class WPML_Term_Translation extends WPML_Element_Translation {
+ 			$this->ttids = array();
  
- 		if ( ! isset( $this->ttids ) || ! isset( $this->term_ids ) ) {
--
--			$data           = $this->wpdb->get_results(
--				'	SELECT wpml_translations.element_id, tax.term_id, tax.taxonomy
--													 ' . $this->get_element_join() . "
--													 JOIN {$this->wpdb->terms} terms
--													  ON terms.term_id = tax.term_id
--													 WHERE tax.term_id != tax.term_taxonomy_id",
-+			$data = $this->wpdb->get_results(
-+				"SELECT wpml_translations.element_id, tax.term_id, tax.taxonomy " .
-+				$this->get_element_join() . " JOIN {$this->wpdb->terms} terms " .
-+				"ON terms.term_id = tax.term_id " .
-+				"WHERE tax.term_id != tax.term_taxonomy_id",
- 				ARRAY_A
- 			);
-+
- 			$this->term_ids = array();
--			$this->ttids    = array();
--			foreach ( $data as $row ) {
--				$this->ttids[ $row['term_id'] ]                     = isset( $this->ttids[ $row['term_id'] ] )
--					? $this->ttids[ $row['term_id'] ] : array();
--				$this->ttids[ $row['term_id'] ][ $row['taxonomy'] ] = $row['element_id'];
--				$this->term_ids[ $row['element_id'] ]               = $row['term_id'];
-+			$this->ttids = array();
-+
-+			foreach ($data as $row) {
+ 			foreach ($data as $row) {
+-					$this->ttids[$row['term_id']] = isset($this->ttids[$row['term_id']])
+-							? absint($this->ttids[$row['term_id']])
+-							: array();
+-					$this->ttids[$row['term_id']][$row['taxonomy']] = absint($row['element_id']);
+-					$this->term_ids[$row['element_id']] = absint($row['term_id']);
 +				$this->ttids[$row['term_id']] = isset($this->ttids[$row['term_id']])
 +					? absint($this->ttids[$row['term_id']])
 +					: array();
 +				$this->ttids[$row['term_id']][$row['taxonomy']] = absint($row['element_id']);
 +				$this->term_ids[$row['element_id']] = absint($row['term_id']);
  			}
--		}
-+    }
+ 		}
  	}
- 
- 	/**
 -- 
-2.30.2
+2.34.1
 


### PR DESCRIPTION
- [Page references: Missing refenreces in the reference-filter-form](https://app.asana.com/0/1202867909936929/1204477610224237)
- updated patches because they would throw errors when you try to apply them, after the sitepress-multilingual-cms plugin has been updated.