### PR TITLE
Fixed terms were not queried for current language.

### DIFF
--- a/patches/sitepress-multilingual-cms.0004.fix.term-query-language.patch
+++ b/patches/sitepress-multilingual-cms.0004.fix.term-query-language.patch
@@ -1,0 +1,24 @@
+From 8bc6e353a6c88aa8754e6ee1a1dcbd985fef3d78 Mon Sep 17 00:00:00 2001
+From: Fabian Marz <fabian@netzstrategen.com>
+Date: Thu, 29 Jun 2023 16:27:57 +0200
+Subject: [PATCH] Fixed terms were not queried for current language.
+
+---
+ classes/query-filtering/class-wpml-term-clauses.php | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/classes/query-filtering/class-wpml-term-clauses.php b/classes/query-filtering/class-wpml-term-clauses.php
+index e1f0d096e..8a6653d04 100644
+--- a/classes/query-filtering/class-wpml-term-clauses.php
++++ b/classes/query-filtering/class-wpml-term-clauses.php
+@@ -59,7 +59,6 @@ class WPML_Term_Clauses {
+ 					'_get_term_hierarchy',
+ 					[ 'WPML_Term_Translation_Utils', 'synchronize_terms' ],
+ 					'wp_get_object_terms',
+-					'get_term_by',
+ 				]
+ 			)
+ 		) {
+-- 
+2.30.2
+


### PR DESCRIPTION
This will prevent methods such as `get_term_by('name', …)` to return the term for the current language since the filter is not applied properly and thus terms for other languages will returned too. 

The same issue was marked as "custom code"/"out of support scope" --> https://wpml.org/forums/topic/get_term_byname-dont-work-in-translation/