### PR TITLE
Fixed Trying to access array offset on value of type null in gwconditionallogicdates.

### DIFF
--- a/patches/gwconditionallogicdates.0001.fix.php-warning-access-array-offset-on-value-of-type-null.patch
+++ b/patches/gwconditionallogicdates.0001.fix.php-warning-access-array-offset-on-value-of-type-null.patch
@@ -1,5 +1,5 @@
 From 85659172dab9a80985ebabedf31d6a7fe350ebb7 Mon Sep 17 00:00:00 2001
-From: Nabi <artsanaat@gmail.com>
+From: Nabi <nabi@netzstrategen.com>
 Date: Wed, 3 Jan 2024 17:09:08 +0330
 Subject: [PATCH] Fixed Trying to access array offset on value of type null in
  gwconditionallogicdates.

--- a/patches/gwconditionallogicdates.0001.fix.php-warning-access-array-offset-on-value-of-type-null.patch
+++ b/patches/gwconditionallogicdates.0001.fix.php-warning-access-array-offset-on-value-of-type-null.patch
@@ -1,0 +1,27 @@
+From 85659172dab9a80985ebabedf31d6a7fe350ebb7 Mon Sep 17 00:00:00 2001
+From: Nabi <artsanaat@gmail.com>
+Date: Wed, 3 Jan 2024 17:09:08 +0330
+Subject: [PATCH] Fixed Trying to access array offset on value of type null in
+ gwconditionallogicdates.
+
+---
+ includes/class-gw-conditional-logic-date-fields.php | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/includes/class-gw-conditional-logic-date-fields.php b/includes/class-gw-conditional-logic-date-fields.php
+index da871fa6e..abb30c906 100644
+--- a/includes/class-gw-conditional-logic-date-fields.php
++++ b/includes/class-gw-conditional-logic-date-fields.php
+@@ -586,7 +586,8 @@ if ( ! class_exists( 'GWConditionalLogicDateFields' ) ) {
+ 			 * @see https://secure.helpscout.net/conversation/964227500/13854?folderId=14965
+ 			 */
+ 			if ( ! self::is_valid_timestamp( $target_value ) ) {
+-				$temp_rules   = self::convert_conditional_logic_rules( array( $rule ), $source_field->formId );
++				// If there is no $source_field object, pass the form ID from set_current_form().
++				$temp_rules   = self::convert_conditional_logic_rules( array( $rule ), ! empty( $source_field ) ? $source_field->formId : $this->current_form['id'] );
+ 				$target_value = $temp_rules[0]['value'];
+ 
+ 				if ( ! self::is_valid_timestamp( $value ) && ! empty( $timestamp ) ) {
+-- 
+2.15.0
+


### PR DESCRIPTION
### Task
https://app.asana.com/0/1203644881535274/1205618012155150/f

### Description
```bash
[10-Oct-2023 14:40:59 UTC] PHP Warning:  Trying to access array offset on value of type null in /var/www/share/service.bnn.de/htdocs/wp-content/plugins/gwconditionallogicdates/includes/class-gw-conditional-logic-date-fields.p
hp on line 457

[10-Oct-2023 14:40:59 UTC] PHP Warning:  Trying to access array offset on value of type null in /var/www/share/service.bnn.de/htdocs/wp-content/plugins/gravityforms/forms_model.php on line 4391
```
So from the warning code stack, we can say that is coming from `gwconditionallogicdates` and `gravityforms` plugins.

Checking the `class-gw-conditional-logic-date-fields.php` file [[in line 457](https://github.com/netzstrategen/bnn/blob/de9bf01acbe80dac2e4f62a360e979c247d63a65/wp-content/plugins/gwconditionallogicdates/includes/class-gw-conditional-logic-date-fields.php#L457)](https://github.com/netzstrategen/bnn/blob/de9bf01acbe80dac2e4f62a360e979c247d63a65/wp-content/plugins/gwconditionallogicdates/includes/class-gw-conditional-logic-date-fields.php#L457):

The error comes from `if ( $rule['fieldId'] == '_gpcld_current_time' )` line, And also the function `is_value_match` that contains this line, uses `gform_is_value_match` filter [[at this line](https://github.com/netzstrategen/bnn/blob/de9bf01acbe80dac2e4f62a360e979c247d63a65/wp-content/plugins/gwconditionallogicdates/includes/class-gw-conditional-logic-date-fields.php#L25)](https://github.com/netzstrategen/bnn/blob/de9bf01acbe80dac2e4f62a360e979c247d63a65/wp-content/plugins/gwconditionallogicdates/includes/class-gw-conditional-logic-date-fields.php#L25).

### Checking the plugin version and new release

Current plugin version:

```bash
❯ wp plugin get gwconditionallogicdates --field=version
1.2.12
```

Checking the plugin version on [the vendor website](https://gravitywiz.com/account/downloads/):
1.2.13

So they released a new version, but from [[the change-log](https://gravitywiz.com/wp/wp-admin/admin-ajax.php?action=perk_changelog&perk_id=1870)](https://gravitywiz.com/wp/wp-admin/admin-ajax.php?action=perk_changelog&perk_id=1870) I don’t think they fixed this issue.
