### PR TITLE
update(patches): elasticpress brand-filters-no-results.

### DIFF
--- a/patches/elasticpress.0004.fix.brand-filters-no-results.patch
+++ b/patches/elasticpress.0004.fix.brand-filters-no-results.patch
@@ -1,4 +1,4 @@
-From fb513faee7cbc96dbdd0cf2986f6b146e7921e62 Mon Sep 17 00:00:00 2001
+From 79a58003d50eb19a1b9405ab9a7d7d577b7a5a0e Mon Sep 17 00:00:00 2001
 From: Bogdan Arizancu <bogdan@netzstrategen.com>
 Date: Thu, 8 Sep 2022 16:00:51 +0300
 Subject: [PATCH] Fixed elasticpress facets feature cannot be disabled.
@@ -9,18 +9,18 @@ Upstream: https://github.com/10up/ElasticPress/pull/3002
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/includes/classes/Feature.php b/includes/classes/Feature.php
-index 31c48a8a8..b4e67d211 100644
+index c3ebe4d25..066839644 100644
 --- a/includes/classes/Feature.php
 +++ b/includes/classes/Feature.php
-@@ -186,7 +186,7 @@ abstract class Feature {
+@@ -242,7 +242,7 @@ abstract class Feature {
  
  		$active = false;
  
 -		if ( ! empty( $feature_settings[ $this->slug ] ) && $feature_settings[ $this->slug ]['active'] ) {
 +		if ( ! empty( $feature_settings[ $this->slug ] ) && $feature_settings[ $this->slug ]['active'] && empty( $feature_settings[ $this->slug ]['force_inactive'] ) ) {
- 			$active = true;
- 		}
- 
+ 			$active = ! in_array(
+ 				$this->requirements_status()->get_code(),
+ 				[ FeatureRequirementsStatus::FORCE_DISABLED, FeatureRequirementsStatus::TEMPORARILY_DISABLED ],
 -- 
-2.32.1 (Apple Git-133)
+2.50.1 (Apple Git-155)
 


### PR DESCRIPTION
## Why

The ElasticPress `is_active()` method body changed in a newer version of the plugin. The old patch expected the if-block to contain a single `$active = true;` line, but it was refactored to a multi-line `! in_array()` check against `FORCE_DISABLED`/`TEMPORARILY_DISABLED` status codes. This caused a context mismatch and the patch failed to apply.

The underlying bug (features not being disabled when `force_inactive` is set) is **not fixed by the vendor** — only the surrounding code changed.

## What changed

Regenerated the patch with `wp patch create elasticpress <commit> fix brand-filters-no-results` against the current plugin version. The actual fix — adding `&& empty( $feature_settings[ $this->slug ]['force_inactive'] )` to the `is_active()` condition — is unchanged. Only the context lines in the hunk were updated to match the current file.

## Upstream

https://github.com/10up/ElasticPress/pull/3002